### PR TITLE
Added reset to fix left margin of footer. Repaired things that broke as a result. Removed un-needed commented lines.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,5 +1,35 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+v2.0 | 20110126
+License: none (public domain)
+ */
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+    display: block;
+}
+
 body {
-    //font-family: 'PT Serif', serif;
     font-family: 'Sorts Mill Goudy', serif;
     margin: 0px;
     padding: 0px;
@@ -49,7 +79,6 @@ a {
     font-size: 14px;
     border-bottom: 1px solid #eee;
     font-family: 'Quicksand', sans-serif;
-    //font-family: arial;
     text-shadow: 1px 1px 1px #fff;
     position: fixed;
     width: 100%;
@@ -97,6 +126,11 @@ a {
     -o-transition: width 5s; /* Opera */
     color: blue;
 }
+.logotxt h1 {
+    font-size:2em;
+    display:block;
+    margin:21px 0;
+}
 
 .logo-container .motto {
     margin-top: 75px;
@@ -107,10 +141,12 @@ a {
     color: #000;
 }
 
-.vertical {
+.logotxt h1.vertical {
     -webkit-transform:rotate(270deg);
     -moz-transform:rotate(270deg);
     -o-transform: rotate(270deg);
+    transform: rotate(270deg);
+    margin:22px 0;
 }
 
 #serpsearch {
@@ -120,7 +156,7 @@ a {
 }
 
 .searchbar {
-    margin: 0px auto 10px auto;
+    margin: 36px auto 10px auto;
     width: 550px;
 }
 
@@ -247,6 +283,7 @@ footer {
 
 footer ul {
     margin-top: 50px;
+    margin-bottom:30px;
     list-style-type: none;
     font-family: 'Quicksand', sans-serif;
 }
@@ -259,7 +296,6 @@ footer ul li {
 footer ul li a {
     font-size: 14px;
     color: #999;
-    //text-decoration: underline;
 }
 
 footer ul li a:hover {

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,41 +2,41 @@ $def with(p=0, rows=50, page=1)
 
 $var page: $p
 
-    <header>
-      <div class="logo-container">
-	<div class="logo">
-	  <a class="logotxt" href="http://archive.org">
-	    <h1 style="float: left; margin-left: 130px;">Archive</h1>
-	    <h1 style="letter-spacing: 6px; float: left;"
-		class="vertical">Internet</h1>
-	    <img src="static/imgs/logo.png"
-		 style="position: absolute; width: 150px; left: 125px; top: 60px;"/>
-	  </a>
-	</div>
-	<div class="clearfix"></div>
-	<p class="centertext motto">
-	  Universal Access to All Knowledge
-	</p>
-      </div>
-    </header>
-
-    <div id="content">
-      <form method="POST" name="rawform" id="rawform"
-	    action="/"/>
-	    $#action="http://archive.org/searchresults.php?output=json">
-	<div class="searchbar">
-	  <input class="searchinput" type="text" name="q"
-		 placeholder="Search archive.org" />
-	  <input type="hidden" name="rows" value="$rows"/>
-	  <input type="hidden" name="page" value="$page"/>
-	  <input type="hidden" name="output" value="json"/>
-	  <input type="hidden" name="mediatype_query"
-	    $for mediatype in enumerate(['all', 'audio']):
-              $if loop.index - 1 == int(p):
-  	        value="$mediatype[1]"/>
-	</div>
-	<div class="searchactions">
-	  <input class="searchbtn" type="submit" class="btn" value="Search"/>
-	</div>
-      </form>
+<header>
+    <div class="logo-container">
+        <div class="logo">
+            <a class="logotxt" href="http://archive.org">
+                <h1 style="float: left; margin-left: 130px;">Archive</h1>
+                <h1 style="letter-spacing: 6px; float: left;"
+                    class="vertical">Internet</h1>
+                <img src="static/imgs/logo.png"
+                style="position: absolute; width: 150px; left: 125px; top: 60px;"/>
+            </a>
+        </div>
+        <div class="clearfix"></div>
+        <p class="centertext motto">
+        Universal Access to All Knowledge
+        </p>
     </div>
+</header>
+
+<div id="content">
+    <form method="POST" name="rawform" id="rawform"
+        action="/"/>
+        $#action="http://archive.org/searchresults.php?output=json">
+        <div class="searchbar">
+            <input class="searchinput" type="text" name="q"
+            placeholder="Search archive.org" />
+            <input type="hidden" name="rows" value="$rows"/>
+            <input type="hidden" name="page" value="$page"/>
+            <input type="hidden" name="output" value="json"/>
+            <input type="hidden" name="mediatype_query"
+            $for mediatype in enumerate(['all', 'audio']):
+            $if loop.index - 1 == int(p):
+            value="$mediatype[1]"/>
+        </div>
+        <div class="searchactions">
+            <input class="searchbtn" type="submit" class="btn" value="Search"/>
+        </div>
+    </form>
+</div>


### PR DESCRIPTION
Take a look at these resources:
[what is and why use a reset](http://sixrevisions.com/css/css-tips/css-tip-1-resetting-your-styles-with-css-reset/)
[more information about resets and the more "modern" alternative: normalising](http://stackoverflow.com/questions/6887336/what-is-the-difference-between-normalize-css-and-reset-css)

Chrome was adding a left margin to the footer `<ul>`, which was causing it to appear off-center. Adding a reset fixed this, however it created three problems (as resetting sometimes can). In removing default styling, `<h1>` and `<ul>` elements lost their default styling. `<h1>` elements also lost the font-size property that was supplied by the user-agent stylesheet. These were all reset explicitly.
